### PR TITLE
Audit fixes for `isValidSignature` implementation

### DIFF
--- a/src/EIP7702Proxy.sol
+++ b/src/EIP7702Proxy.sol
@@ -98,7 +98,7 @@ contract EIP7702Proxy is Proxy {
         if (
             success &&
             result.length == 32 &&
-            abi.decode(result, (bytes4)) == ERC1271_MAGIC_VALUE
+            bytes4(result) == ERC1271_MAGIC_VALUE
         ) {
             return ERC1271_MAGIC_VALUE;
         }

--- a/test/EIP7702Proxy/initialize.t.sol
+++ b/test/EIP7702Proxy/initialize.t.sol
@@ -116,8 +116,9 @@ contract InitializeTest is EIP7702ProxyBase {
         vm.assume(address(secondProxy) != address(0));
         vm.assume(address(secondProxy) != address(_eoa));
         assumeNotPrecompile(address(secondProxy));
-        assumeNotPrecompile(newOwner);
-
+        vm.assume(newOwner != address(0));
+        vm.assume(newOwner != address(_eoa));
+        vm.assume(newOwner != address(secondProxy));
         // Get signature for first proxy
         bytes memory initArgs = _createInitArgs(newOwner);
         bytes memory signature = _signInitData(_EOA_PRIVATE_KEY, initArgs);

--- a/test/mocks/MockImplementation.sol
+++ b/test/mocks/MockImplementation.sol
@@ -121,3 +121,22 @@ contract RevertingInitializerMockImplementation is MockImplementation {
         revert("InitializerReverted");
     }
 }
+
+/**
+ * @dev Mock implementation that returns ERC1271_MAGIC_VALUE with extra data
+ */
+contract MockImplementationWithExtraData is MockImplementation {
+    function isValidSignature(
+        bytes32,
+        bytes memory
+    ) public pure override returns (bytes4) {
+        // Return magic value (0x1626ba7e) followed by extra data
+        bytes32 returnValue = bytes32(bytes4(ERC1271_MAGIC_VALUE)) |
+            bytes32(uint256(0xdeadbeef) << 32);
+        assembly {
+            // Need assembly to return more than 4 bytes from a function declared to return bytes4
+            mstore(0x00, returnValue)
+            return(0x00, 32)
+        }
+    }
+}


### PR DESCRIPTION
Fixes audit findings around `isValidSignature` implementation on the proxy:

1) Entire 32 bytes of data returned by isValidSignature delegatecall should be checked
- Potentially the implementation contract can return extra 28 bytes (result = magic_value_4_bytes | extra_28_bytes). In that case it is likely that the decoding to bytes4 will revert. 
- This change handles the return value from `isValidSignature` in a way that doesn't revert if there is nonzero data beyond the 4 byte magic value.

2) Function EIP7702Proxy.isValidSignature can revert unexpectedly
- Signature malformations beyond simple incorrect length were not being handled correctly. 
- By using `ECDSA.tryRecover` we can fail gracefully regardless of types of malformations.

3) Different behaviour of isValidSignature function for implementation contracts

- The EIP7702Proxy.isValidSignature implements ECDSA based signature validation for EOA along with EIP1271 based signature validation for contracts.
- In case the implementation contract also has an isValidSignature function marked as public then in the implementation code:
    - calling isValidSignature() will perform implementation contract specific validation, and won't check for ECDSA based EOA signatures
    - calling this.isValidSignature() will perform EIP7702Proxy specific validation and will check for ECDSA based EOA signatures
    
Unfortunately we can't make the `isValidSignature` on the implementation `external` because 1) we can't modify our implementation and 2) our implementation inherits from OZ's 1271 abstract which declares it as public.

We address this discrepancy with documentation instead, and it's the responsibility of the implementation contract to correctly use `isValidSignature` in the way intended.