### PR TITLE
Add typehash to initialization signature

### DIFF
--- a/src/EIP7702Proxy.sol
+++ b/src/EIP7702Proxy.sol
@@ -17,7 +17,7 @@ contract EIP7702Proxy is Proxy {
 
     /// @notice Typehash for initialization signatures
     bytes32 private constant INIT_TYPEHASH =
-        keccak256("EIP7702ProxyInitialize(address proxy,bytes args)");
+        keccak256("EIP7702ProxyInitialization(address proxy,bytes args)");
 
     /// @notice Address of this proxy contract delegate
     address immutable proxy;

--- a/test/EIP7702Proxy/coinbaseImplementation.t.sol
+++ b/test/EIP7702Proxy/coinbaseImplementation.t.sol
@@ -71,7 +71,12 @@ contract CoinbaseImplementationTest is Test {
         uint256 signerPk,
         bytes memory initArgs
     ) internal view returns (bytes memory) {
-        bytes32 initHash = keccak256(abi.encode(proxy, initArgs));
+        bytes32 INIT_TYPEHASH = keccak256(
+            "EIP7702ProxyInitialize(address proxy,bytes args)"
+        );
+        bytes32 initHash = keccak256(
+            abi.encode(INIT_TYPEHASH, proxy, keccak256(initArgs))
+        );
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPk, initHash);
         return abi.encodePacked(r, s, v);
     }

--- a/test/EIP7702Proxy/coinbaseImplementation.t.sol
+++ b/test/EIP7702Proxy/coinbaseImplementation.t.sol
@@ -72,7 +72,7 @@ contract CoinbaseImplementationTest is Test {
         bytes memory initArgs
     ) internal view returns (bytes memory) {
         bytes32 INIT_TYPEHASH = keccak256(
-            "EIP7702ProxyInitialize(address proxy,bytes args)"
+            "EIP7702ProxyInitialization(address proxy,bytes args)"
         );
         bytes32 initHash = keccak256(
             abi.encode(INIT_TYPEHASH, proxy, keccak256(initArgs))

--- a/test/EIP7702Proxy/initialize.t.sol
+++ b/test/EIP7702Proxy/initialize.t.sol
@@ -203,7 +203,7 @@ contract InitializeTest is EIP7702ProxyBase {
         // Initialize the proxy
         bytes memory initArgs = _createInitArgs(_newOwner);
         bytes32 INIT_TYPEHASH = keccak256(
-            "EIP7702ProxyInitialize(address proxy,bytes args)"
+            "EIP7702ProxyInitialization(address proxy,bytes args)"
         );
         bytes32 initHash = keccak256(
             abi.encode(

--- a/test/EIP7702Proxy/initialize.t.sol
+++ b/test/EIP7702Proxy/initialize.t.sol
@@ -202,8 +202,15 @@ contract InitializeTest is EIP7702ProxyBase {
 
         // Initialize the proxy
         bytes memory initArgs = _createInitArgs(_newOwner);
+        bytes32 INIT_TYPEHASH = keccak256(
+            "EIP7702ProxyInitialize(address proxy,bytes args)"
+        );
         bytes32 initHash = keccak256(
-            abi.encode(address(proxyTemplate), initArgs)
+            abi.encode(
+                INIT_TYPEHASH,
+                address(proxyTemplate),
+                keccak256(initArgs)
+            )
         );
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(uninitProxyPk, initHash);
         bytes memory signature = abi.encodePacked(r, s, v);

--- a/test/base/EIP7702ProxyBase.sol
+++ b/test/base/EIP7702ProxyBase.sol
@@ -59,7 +59,12 @@ abstract contract EIP7702ProxyBase is Test {
         uint256 signerPk,
         bytes memory initArgs
     ) internal view returns (bytes memory) {
-        bytes32 initHash = keccak256(abi.encode(_proxy, initArgs));
+        bytes32 INIT_TYPEHASH = keccak256(
+            "EIP7702ProxyInitialize(address proxy,bytes args)"
+        );
+        bytes32 initHash = keccak256(
+            abi.encode(INIT_TYPEHASH, _proxy, keccak256(initArgs))
+        );
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPk, initHash);
         return abi.encodePacked(r, s, v);
     }
@@ -105,5 +110,17 @@ abstract contract EIP7702ProxyBase is Test {
         vm.etch(target, proxyCode);
 
         return target;
+    }
+
+    /// @dev Helper to create initialization data hash
+    function _createInitHash(
+        address proxyAddress,
+        bytes memory args
+    ) internal pure returns (bytes32) {
+        bytes32 INIT_TYPEHASH = keccak256(
+            "EIP7702ProxyInitialize(address proxy,bytes args)"
+        );
+        return
+            keccak256(abi.encode(INIT_TYPEHASH, proxyAddress, keccak256(args)));
     }
 }

--- a/test/base/EIP7702ProxyBase.sol
+++ b/test/base/EIP7702ProxyBase.sol
@@ -111,16 +111,4 @@ abstract contract EIP7702ProxyBase is Test {
 
         return target;
     }
-
-    /// @dev Helper to create initialization data hash
-    function _createInitHash(
-        address proxyAddress,
-        bytes memory args
-    ) internal pure returns (bytes32) {
-        bytes32 INIT_TYPEHASH = keccak256(
-            "EIP7702ProxyInitialize(address proxy,bytes args)"
-        );
-        return
-            keccak256(abi.encode(INIT_TYPEHASH, proxyAddress, keccak256(args)));
-    }
 }

--- a/test/base/EIP7702ProxyBase.sol
+++ b/test/base/EIP7702ProxyBase.sol
@@ -60,7 +60,7 @@ abstract contract EIP7702ProxyBase is Test {
         bytes memory initArgs
     ) internal view returns (bytes memory) {
         bytes32 INIT_TYPEHASH = keccak256(
-            "EIP7702ProxyInitialize(address proxy,bytes args)"
+            "EIP7702ProxyInitialization(address proxy,bytes args)"
         );
         bytes32 initHash = keccak256(
             abi.encode(INIT_TYPEHASH, _proxy, keccak256(initArgs))


### PR DESCRIPTION
Address audit finding "Signing unstructured data could introduce the risk of signed data collision or signature reuse"