### PR TITLE
Add optional `chainId` to `initialize`

### DIFF
--- a/script/Initialize.s.sol
+++ b/script/Initialize.s.sol
@@ -115,7 +115,7 @@ contract Initialize is Script {
         vm.startBroadcast(eoaPk);
 
         // Try to initialize, but handle the case where it's already initialized
-        try EIP7702Proxy(payable(eoa)).initialize(initArgs, initSignature) {
+        try EIP7702Proxy(payable(eoa)).initialize(initArgs, initSignature, 0) {
             console.log("[OK] Successfully initialized the smart wallet");
         } catch Error(string memory reason) {
             console.log("[INFO] Initialize call reverted with reason:", reason);

--- a/src/EIP7702Proxy.sol
+++ b/src/EIP7702Proxy.sol
@@ -98,9 +98,8 @@ contract EIP7702Proxy is Proxy {
     ) external {
         uint256 expectedNonce = NONCE_TRACKER.getNextNonce(address(this));
 
-        uint256 currentChainId = block.chainid;
-
         // Verify chain ID if specified (revert if non-zero and doesn't match)
+        uint256 currentChainId = block.chainid;
         if (chainId != 0 && chainId != currentChainId) {
             revert InvalidChainId();
         }

--- a/src/EIP7702Proxy.sol
+++ b/src/EIP7702Proxy.sol
@@ -23,7 +23,7 @@ contract EIP7702Proxy is Proxy {
     /// @notice Typehash for initialization signatures
     bytes32 private constant INIT_TYPEHASH =
         keccak256(
-            "EIP7702ProxyInitialization(address proxy,bytes32 args,uint256 nonce)"
+            "EIP7702ProxyInitialization(uint256 chainId,address proxy,bytes32 args,uint256 nonce)"
         );
 
     /// @notice Typehash for resetting implementation, including chainId and current implementation
@@ -90,15 +90,30 @@ contract EIP7702Proxy is Proxy {
     ///
     /// @param args The initialization arguments for the implementation
     /// @param signature The signature authorizing initialization
+    /// @param chainId Optional: if 0, allows cross-chain signatures
     function initialize(
         bytes calldata args,
-        bytes calldata signature
+        bytes calldata signature,
+        uint256 chainId
     ) external {
         uint256 expectedNonce = NONCE_TRACKER.getNextNonce(address(this));
 
+        uint256 currentChainId = block.chainid;
+
+        // Verify chain ID if specified (revert if non-zero and doesn't match)
+        if (chainId != 0 && chainId != currentChainId) {
+            revert InvalidChainId();
+        }
+
         // Construct hash using typehash to prevent signature collisions
         bytes32 initHash = keccak256(
-            abi.encode(INIT_TYPEHASH, PROXY, keccak256(args), expectedNonce)
+            abi.encode(
+                INIT_TYPEHASH,
+                chainId == 0 ? 0 : currentChainId,
+                PROXY,
+                keccak256(args),
+                expectedNonce
+            )
         );
 
         // Verify signature is from the EOA

--- a/test/EIP7702Proxy/coinbaseImplementation.t.sol
+++ b/test/EIP7702Proxy/coinbaseImplementation.t.sol
@@ -50,7 +50,7 @@ contract CoinbaseImplementationTest is Test {
 
         bytes memory initArgs = _createInitArgs(_newOwner);
         bytes memory signature = _signInitData(_EOA_PRIVATE_KEY, initArgs);
-        EIP7702Proxy(_eoa).initialize(initArgs, signature);
+        EIP7702Proxy(_eoa).initialize(initArgs, signature, 0);
 
         wallet = CoinbaseSmartWallet(payable(_eoa));
     }
@@ -80,11 +80,12 @@ contract CoinbaseImplementationTest is Test {
         bytes memory initArgs
     ) internal view returns (bytes memory) {
         bytes32 INIT_TYPEHASH = keccak256(
-            "EIP7702ProxyInitialization(address proxy,bytes32 args,uint256 nonce)"
+            "EIP7702ProxyInitialization(uint256 chainId,address proxy,bytes32 args,uint256 nonce)"
         );
         bytes32 initHash = keccak256(
             abi.encode(
                 INIT_TYPEHASH,
+                0,
                 proxy,
                 keccak256(initArgs),
                 nonceTracker.getNextNonce(_eoa)
@@ -239,6 +240,6 @@ contract CoinbaseImplementationTest is Test {
 
         // Try to initialize again
         vm.expectRevert(CoinbaseSmartWallet.Initialized.selector);
-        EIP7702Proxy(_eoa).initialize(initArgs, signature);
+        EIP7702Proxy(_eoa).initialize(initArgs, signature, 0);
     }
 }

--- a/test/EIP7702Proxy/delegate.t.sol
+++ b/test/EIP7702Proxy/delegate.t.sol
@@ -15,7 +15,7 @@ contract DelegateTest is EIP7702ProxyBase {
         // Initialize the proxy
         bytes memory initArgs = _createInitArgs(_newOwner);
         bytes memory signature = _signInitData(_EOA_PRIVATE_KEY, initArgs);
-        EIP7702Proxy(_eoa).initialize(initArgs, signature);
+        EIP7702Proxy(_eoa).initialize(initArgs, signature, 0);
     }
 
     function test_succeeds_whenReadingState() public {

--- a/test/EIP7702Proxy/initialize.t.sol
+++ b/test/EIP7702Proxy/initialize.t.sol
@@ -19,7 +19,61 @@ contract InitializeTest is EIP7702ProxyBase {
         bytes memory initArgs = _createInitArgs(newOwner);
         bytes memory signature = _signInitData(_EOA_PRIVATE_KEY, initArgs);
 
-        EIP7702Proxy(_eoa).initialize(initArgs, signature);
+        EIP7702Proxy(_eoa).initialize(initArgs, signature, 0);
+
+        // Verify owner was set correctly
+        assertTrue(
+            MockImplementation(payable(_eoa)).owner() == newOwner,
+            "Owner should be set to fuzzed address"
+        );
+    }
+
+    function test_succeeds_withChainIdZero(address newOwner) public {
+        vm.assume(newOwner != address(0));
+        assumeNotPrecompile(newOwner);
+
+        bytes memory initArgs = _createInitArgs(newOwner);
+        bytes32 INIT_TYPEHASH = keccak256(
+            "EIP7702ProxyInitialization(uint256 chainId,address proxy,bytes32 args,uint256 nonce)"
+        );
+        uint256 nonce = _nonceTracker.getNextNonce(address(_eoa));
+        bytes32 initHash = keccak256(
+            abi.encode(INIT_TYPEHASH, 0, _proxy, keccak256(initArgs), nonce)
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(_EOA_PRIVATE_KEY, initHash);
+        bytes memory signature = abi.encodePacked(r, s, v);
+
+        EIP7702Proxy(_eoa).initialize(initArgs, signature, 0);
+
+        // Verify owner was set correctly
+        assertTrue(
+            MockImplementation(payable(_eoa)).owner() == newOwner,
+            "Owner should be set to fuzzed address"
+        );
+    }
+
+    function test_succeeds_withNonzeroChainId(address newOwner) public {
+        vm.assume(newOwner != address(0));
+        assumeNotPrecompile(newOwner);
+
+        bytes memory initArgs = _createInitArgs(newOwner);
+        bytes32 INIT_TYPEHASH = keccak256(
+            "EIP7702ProxyInitialization(uint256 chainId,address proxy,bytes32 args,uint256 nonce)"
+        );
+        uint256 nonce = _nonceTracker.getNextNonce(address(_eoa));
+        bytes32 initHash = keccak256(
+            abi.encode(
+                INIT_TYPEHASH,
+                block.chainid,
+                _proxy,
+                keccak256(initArgs),
+                nonce
+            )
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(_EOA_PRIVATE_KEY, initHash);
+        bytes memory signature = abi.encodePacked(r, s, v);
+
+        EIP7702Proxy(_eoa).initialize(initArgs, signature, block.chainid);
 
         // Verify owner was set correctly
         assertTrue(
@@ -35,7 +89,7 @@ contract InitializeTest is EIP7702ProxyBase {
         bytes memory initArgs = _createInitArgs(newOwner);
         bytes memory signature = _signInitData(_EOA_PRIVATE_KEY, initArgs);
 
-        EIP7702Proxy(_eoa).initialize(initArgs, signature);
+        EIP7702Proxy(_eoa).initialize(initArgs, signature, 0);
 
         address storedImpl = _getERC1967Implementation(address(_eoa));
         assertEq(
@@ -50,7 +104,7 @@ contract InitializeTest is EIP7702ProxyBase {
         bytes memory signature = _signInitData(_EOA_PRIVATE_KEY, initArgs);
         vm.expectEmit(true, false, false, false, address(_eoa));
         emit IERC1967.Upgraded(address(_implementation));
-        EIP7702Proxy(_eoa).initialize(initArgs, signature);
+        EIP7702Proxy(_eoa).initialize(initArgs, signature, 0);
     }
 
     function test_succeeds_whenImplementationSlotAlreadySetToDifferentAddress(
@@ -98,11 +152,12 @@ contract InitializeTest is EIP7702ProxyBase {
         // Initialize the proxy
         bytes memory initArgs = _createInitArgs(_newOwner);
         bytes32 INIT_TYPEHASH = keccak256(
-            "EIP7702ProxyInitialization(address proxy,bytes32 args,uint256 nonce)"
+            "EIP7702ProxyInitialization(uint256 chainId,address proxy,bytes32 args,uint256 nonce)"
         );
         bytes32 initHash = keccak256(
             abi.encode(
                 INIT_TYPEHASH,
+                0,
                 address(proxyTemplate),
                 keccak256(initArgs),
                 _nonceTracker.getNextNonce(address(proxyTemplate))
@@ -111,7 +166,7 @@ contract InitializeTest is EIP7702ProxyBase {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(uninitProxyPk, initHash);
         bytes memory signature = abi.encodePacked(r, s, v);
 
-        EIP7702Proxy(uninitProxy).initialize(initArgs, signature);
+        EIP7702Proxy(uninitProxy).initialize(initArgs, signature, 0);
 
         // Verify implementation slot was changed to the correct implementation
         assertEq(
@@ -134,7 +189,7 @@ contract InitializeTest is EIP7702ProxyBase {
         // Perform initialization
         bytes memory initArgs = _createInitArgs(_newOwner);
         bytes memory signature = _signInitData(_EOA_PRIVATE_KEY, initArgs);
-        EIP7702Proxy(_eoa).initialize(initArgs, signature);
+        EIP7702Proxy(_eoa).initialize(initArgs, signature, 0);
 
         uint256 newNonce = _nonceTracker.getNextNonce(_eoa);
         assertEq(
@@ -151,7 +206,7 @@ contract InitializeTest is EIP7702ProxyBase {
         vm.expectRevert(
             abi.encodeWithSignature("ECDSAInvalidSignatureLength(uint256)", 4)
         );
-        EIP7702Proxy(_eoa).initialize(initArgs, signature);
+        EIP7702Proxy(_eoa).initialize(initArgs, signature, 0);
     }
 
     function test_reverts_whenSignatureInvalid(address newOwner) public {
@@ -160,7 +215,7 @@ contract InitializeTest is EIP7702ProxyBase {
         bytes memory signature = new bytes(65);
 
         vm.expectRevert(abi.encodeWithSignature("ECDSAInvalidSignature()"));
-        EIP7702Proxy(_eoa).initialize(initArgs, signature);
+        EIP7702Proxy(_eoa).initialize(initArgs, signature, 0);
     }
 
     function test_reverts_whenSignerWrong(uint128 wrongPk) public {
@@ -175,7 +230,7 @@ contract InitializeTest is EIP7702ProxyBase {
         bytes memory signature = abi.encodePacked(r, s, v);
 
         vm.expectRevert(EIP7702Proxy.InvalidSignature.selector);
-        EIP7702Proxy(_eoa).initialize(initArgs, signature);
+        EIP7702Proxy(_eoa).initialize(initArgs, signature, 0);
     }
 
     function test_reverts_whenDelegatecallFails(address newOwner) public {
@@ -206,7 +261,7 @@ contract InitializeTest is EIP7702ProxyBase {
         bytes memory signature = _signInitData(_EOA_PRIVATE_KEY, initArgs);
 
         vm.expectRevert("InitializerReverted");
-        EIP7702Proxy(_eoa).initialize(initArgs, signature);
+        EIP7702Proxy(_eoa).initialize(initArgs, signature, 0);
     }
 
     function test_reverts_whenSignatureReplayedWithDifferentProxy(
@@ -236,7 +291,7 @@ contract InitializeTest is EIP7702ProxyBase {
 
         // Try to use same signature with different proxy
         vm.expectRevert(EIP7702Proxy.InvalidSignature.selector);
-        EIP7702Proxy(secondProxy).initialize(initArgs, signature);
+        EIP7702Proxy(secondProxy).initialize(initArgs, signature, 0);
     }
 
     function test_reverts_whenSignatureReplayedWithDifferentArgs(
@@ -255,7 +310,7 @@ contract InitializeTest is EIP7702ProxyBase {
         // Try to use same signature with different args
         bytes memory differentArgs = _createInitArgs(differentOwner);
         vm.expectRevert(EIP7702Proxy.InvalidSignature.selector);
-        EIP7702Proxy(_eoa).initialize(differentArgs, signature);
+        EIP7702Proxy(_eoa).initialize(differentArgs, signature, 0);
     }
 
     function test_reverts_whenSignatureUsesWrongNonce() public {
@@ -271,17 +326,17 @@ contract InitializeTest is EIP7702ProxyBase {
         bytes memory signature = abi.encodePacked(r, s, v);
 
         vm.expectRevert(EIP7702Proxy.InvalidSignature.selector);
-        EIP7702Proxy(_eoa).initialize(initArgs, signature);
+        EIP7702Proxy(_eoa).initialize(initArgs, signature, 0);
     }
 
     function test_reverts_whenSignatureReplayedWithSameNonce() public {
         // First initialization
         bytes memory initArgs = _createInitArgs(_newOwner);
         bytes memory signature = _signInitData(_EOA_PRIVATE_KEY, initArgs);
-        EIP7702Proxy(_eoa).initialize(initArgs, signature);
+        EIP7702Proxy(_eoa).initialize(initArgs, signature, 0);
 
         // Try to replay the same signature
         vm.expectRevert(EIP7702Proxy.InvalidSignature.selector);
-        EIP7702Proxy(_eoa).initialize(initArgs, signature);
+        EIP7702Proxy(_eoa).initialize(initArgs, signature, 0);
     }
 }

--- a/test/EIP7702Proxy/isValidSignature.t.sol
+++ b/test/EIP7702Proxy/isValidSignature.t.sol
@@ -102,7 +102,7 @@ contract FailingImplementationTest is IsValidSignatureTestBase {
         // Initialize
         bytes memory initArgs = _createInitArgs(_newOwner);
         bytes memory signature = _signInitData(_EOA_PRIVATE_KEY, initArgs);
-        EIP7702Proxy(_eoa).initialize(initArgs, signature);
+        EIP7702Proxy(_eoa).initialize(initArgs, signature, 0);
     }
 
     function expectedInvalidSignatureResult()
@@ -260,7 +260,7 @@ contract SucceedingImplementationTest is IsValidSignatureTestBase {
         // Initialize
         bytes memory initArgs = _createInitArgs(_newOwner);
         bytes memory signature = _signInitData(_EOA_PRIVATE_KEY, initArgs);
-        EIP7702Proxy(_eoa).initialize(initArgs, signature);
+        EIP7702Proxy(_eoa).initialize(initArgs, signature, 0);
     }
 
     function expectedInvalidSignatureResult()
@@ -313,7 +313,7 @@ contract RevertingImplementationTest is IsValidSignatureTestBase {
         // Initialize
         bytes memory initArgs = _createInitArgs(_newOwner);
         bytes memory signature = _signInitData(_EOA_PRIVATE_KEY, initArgs);
-        EIP7702Proxy(_eoa).initialize(initArgs, signature);
+        EIP7702Proxy(_eoa).initialize(initArgs, signature, 0);
     }
 
     function expectedInvalidSignatureResult()
@@ -374,7 +374,7 @@ contract ExtraDataTest is IsValidSignatureTestBase {
         // Initialize
         bytes memory initArgs = _createInitArgs(_newOwner);
         bytes memory signature = _signInitData(_EOA_PRIVATE_KEY, initArgs);
-        EIP7702Proxy(_eoa).initialize(initArgs, signature);
+        EIP7702Proxy(_eoa).initialize(initArgs, signature, 0);
 
         super.setUp();
     }

--- a/test/EIP7702Proxy/resetImplementation.t.sol
+++ b/test/EIP7702Proxy/resetImplementation.t.sol
@@ -375,11 +375,12 @@ contract ResetImplementationTest is EIP7702ProxyBase {
         vm.etch(secondProxy, proxyCode);
         bytes memory initArgs = _createInitArgs(_newOwner);
         bytes32 INIT_TYPEHASH = keccak256(
-            "EIP7702ProxyInitialization(address proxy,bytes32 args,uint256 nonce)"
+            "EIP7702ProxyInitialization(uint256 chainId,address proxy,bytes32 args,uint256 nonce)"
         );
         bytes32 initHash = keccak256(
             abi.encode(
                 INIT_TYPEHASH,
+                0,
                 _proxy,
                 keccak256(initArgs),
                 _nonceTracker.getNextNonce(secondProxy) // can't use util signature function because we need to use the second proxy's nonce
@@ -387,7 +388,7 @@ contract ResetImplementationTest is EIP7702ProxyBase {
         );
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(secondProxyPk, initHash);
         bytes memory initSignature = abi.encodePacked(r, s, v);
-        EIP7702Proxy(secondProxy).initialize(initArgs, initSignature);
+        EIP7702Proxy(secondProxy).initialize(initArgs, initSignature, 0);
 
         // Get signature for first proxy
         bytes memory signature = _signResetData(

--- a/test/EIP7702Proxy/upgradeToAndCall.t.sol
+++ b/test/EIP7702Proxy/upgradeToAndCall.t.sol
@@ -21,7 +21,7 @@ contract UpgradeToAndCallTest is EIP7702ProxyBase {
         // Initialize the proxy first
         bytes memory initArgs = _createInitArgs(_newOwner);
         bytes memory signature = _signInitData(_EOA_PRIVATE_KEY, initArgs);
-        EIP7702Proxy(_eoa).initialize(initArgs, signature);
+        EIP7702Proxy(_eoa).initialize(initArgs, signature, 0);
 
         // Deploy new implementation
         newImplementation = new MockImplementation();

--- a/test/base/EIP7702ProxyBase.sol
+++ b/test/base/EIP7702ProxyBase.sol
@@ -68,11 +68,11 @@ abstract contract EIP7702ProxyBase is Test {
         bytes memory initArgs
     ) internal view returns (bytes memory) {
         bytes32 INIT_TYPEHASH = keccak256(
-            "EIP7702ProxyInitialization(address proxy,bytes32 args,uint256 nonce)"
+            "EIP7702ProxyInitialization(uint256 chainId,address proxy,bytes32 args,uint256 nonce)"
         );
         uint256 nonce = _nonceTracker.getNextNonce(address(_eoa));
         bytes32 initHash = keccak256(
-            abi.encode(INIT_TYPEHASH, _proxy, keccak256(initArgs), nonce)
+            abi.encode(INIT_TYPEHASH, 0, _proxy, keccak256(initArgs), nonce)
         );
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPk, initHash);
         return abi.encodePacked(r, s, v);


### PR DESCRIPTION
Adds an optional chain id (0 for cross-chain replayable) to the `initialize` function, which can be used to protect against cross-chain use of initialization payloads if desired, and brings the two instances of signature verification (`initialize` and `resetImplementation`) to parity.