### PR TITLE
fix: fix typo in the GUARDED_INTIALIZER constant

### DIFF
--- a/src/EIP7702Proxy.sol
+++ b/src/EIP7702Proxy.sol
@@ -49,7 +49,7 @@ contract EIP7702Proxy is Proxy {
     /// @notice Initialization signature is invalid
     error InvalidSignature();
 
-    /// @notice Call to `GUARDED_INTIALIZER` attempted
+    /// @notice Call to `GUARDED_INITIALIZER` attempted
     error InvalidInitializer();
 
     /// @notice Initializes the proxy with an initial implementation and guarded initializer


### PR DESCRIPTION
I corrected a typo in the constant `GUARDED_INTIALIZER`. The word `INTIALIZER` was misspelled, and it has been fixed to `INITIALIZER`.