### PR TITLE
Couple validator and implementation to be validated

### DIFF
--- a/src/EIP7702Proxy.sol
+++ b/src/EIP7702Proxy.sol
@@ -8,7 +8,7 @@ import {Receiver} from "solady/accounts/Receiver.sol";
 
 import {NonceTracker} from "./NonceTracker.sol";
 import {DefaultReceiver} from "./DefaultReceiver.sol";
-import {IAccountStateValidator} from "./interfaces/IAccountStateValidator.sol";
+import {IAccountStateValidator, VALIDATION_SUCCESS} from "./interfaces/IAccountStateValidator.sol";
 
 /// @title EIP7702Proxy
 ///
@@ -41,6 +41,9 @@ contract EIP7702Proxy is Proxy {
 
     /// @notice EOA signature is invalid
     error InvalidSignature();
+
+    /// @notice Validator did not return VALIDATION_SUCCESS
+    error InvalidValidation();
 
     /// @notice Initializes the proxy with a default receiver implementation and an external nonce tracker
     ///
@@ -94,7 +97,11 @@ contract EIP7702Proxy is Proxy {
         ERC1967Utils.upgradeToAndCall(newImplementation, callData);
 
         // Validate wallet state after upgrade, reverting if invalid
-        IAccountStateValidator(validator).validateAccountState(address(this), newImplementation);
+        bytes4 validationResult =
+            IAccountStateValidator(validator).validateAccountState(address(this), newImplementation);
+        if (validationResult != VALIDATION_SUCCESS) {
+            revert InvalidValidation();
+        }
     }
 
     /// @notice Handles ERC-1271 signature validation by enforcing a final `ecrecover` check if signatures fail `isValidSignature` check

--- a/src/EIP7702Proxy.sol
+++ b/src/EIP7702Proxy.sol
@@ -94,7 +94,7 @@ contract EIP7702Proxy is Proxy {
         ERC1967Utils.upgradeToAndCall(newImplementation, callData);
 
         // Validate wallet state after upgrade, reverting if invalid
-        IAccountStateValidator(validator).validateAccountState(address(this));
+        IAccountStateValidator(validator).validateAccountState(address(this), newImplementation);
     }
 
     /// @notice Handles ERC-1271 signature validation by enforcing a final `ecrecover` check if signatures fail `isValidSignature` check

--- a/src/EIP7702Proxy.sol
+++ b/src/EIP7702Proxy.sol
@@ -8,7 +8,7 @@ import {Receiver} from "solady/accounts/Receiver.sol";
 
 import {NonceTracker} from "./NonceTracker.sol";
 import {DefaultReceiver} from "./DefaultReceiver.sol";
-import {IAccountStateValidator, VALIDATION_SUCCESS} from "./interfaces/IAccountStateValidator.sol";
+import {IAccountStateValidator, ACCOUNT_STATE_VALIDATION_SUCCESS} from "./interfaces/IAccountStateValidator.sol";
 
 /// @title EIP7702Proxy
 ///
@@ -42,7 +42,7 @@ contract EIP7702Proxy is Proxy {
     /// @notice EOA signature is invalid
     error InvalidSignature();
 
-    /// @notice Validator did not return VALIDATION_SUCCESS
+    /// @notice Validator did not return ACCOUNT_STATE_VALIDATION_SUCCESS
     error InvalidValidation();
 
     /// @notice Initializes the proxy with a default receiver implementation and an external nonce tracker
@@ -99,9 +99,7 @@ contract EIP7702Proxy is Proxy {
         // Validate wallet state after upgrade, reverting if invalid
         bytes4 validationResult =
             IAccountStateValidator(validator).validateAccountState(address(this), newImplementation);
-        if (validationResult != VALIDATION_SUCCESS) {
-            revert InvalidValidation();
-        }
+        if (validationResult != ACCOUNT_STATE_VALIDATION_SUCCESS) revert InvalidValidation();
     }
 
     /// @notice Handles ERC-1271 signature validation by enforcing a final `ecrecover` check if signatures fail `isValidSignature` check

--- a/src/interfaces/IAccountStateValidator.sol
+++ b/src/interfaces/IAccountStateValidator.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
+/// @dev Magic value returned by validateAccountState on success
+bytes4 constant VALIDATION_SUCCESS = 0x61014884; // bytes4(keccak256("validateAccountState(address,address)"))
+
 /// @title IAccountStateValidator
-///
-/// @notice Interface for account-specific validation logic
-///
+/// @notice Interface for account-specific validation logi
 /// @dev This interface is used to validate the state of a account after an upgrade
-///
 /// @author Coinbase (https://github.com/base/eip-7702-proxy)
 interface IAccountStateValidator {
     /// @notice Error thrown when the implementation provided to `validateAccountState` is not the validator's expected implementation
@@ -14,9 +14,10 @@ interface IAccountStateValidator {
 
     /// @notice Validates that an account is in a valid state
     ///
-    /// @dev Should revert if account state is invalid
+    /// @dev Should return VALIDATION_SUCCESS if account state is valid, otherwise revert
     ///
     /// @param account The address of the account to validate
     /// @param implementation The address of the implementation this validator expects
-    function validateAccountState(address account, address implementation) external view;
+    /// @return The magic value VALIDATION_SUCCESS if validation succeeds
+    function validateAccountState(address account, address implementation) external view returns (bytes4);
 }

--- a/src/interfaces/IAccountStateValidator.sol
+++ b/src/interfaces/IAccountStateValidator.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.23;
 
 /// @dev Magic value returned by validateAccountState on success
-bytes4 constant VALIDATION_SUCCESS = 0x61014884; // bytes4(keccak256("validateAccountState(address,address)"))
+bytes4 constant ACCOUNT_STATE_VALIDATION_SUCCESS = 0x61014884; // bytes4(keccak256("validateAccountState(address,address)"))
 
 /// @title IAccountStateValidator
 /// @notice Interface for account-specific validation logi
@@ -12,12 +12,14 @@ interface IAccountStateValidator {
     /// @notice Error thrown when the implementation provided to `validateAccountState` is not the validator's expected implementation
     error InvalidImplementation(address expected, address actual);
 
+    /// @notice Returns the address of the implementation this validator is willing to validate
+    function supportedImplementation() external view returns (address);
+
     /// @notice Validates that an account is in a valid state
-    ///
-    /// @dev Should return VALIDATION_SUCCESS if account state is valid, otherwise revert
-    ///
+    /// @dev Should return ACCOUNT_STATE_VALIDATION_SUCCESS if account state is valid, otherwise revert
+    /// @dev Should validate that the provided implementation is the expected implementation for this validator
     /// @param account The address of the account to validate
     /// @param implementation The address of the implementation this validator expects
-    /// @return The magic value VALIDATION_SUCCESS if validation succeeds
+    /// @return The magic value ACCOUNT_STATE_VALIDATION_SUCCESS if validation succeeds
     function validateAccountState(address account, address implementation) external view returns (bytes4);
 }

--- a/src/interfaces/IAccountStateValidator.sol
+++ b/src/interfaces/IAccountStateValidator.sol
@@ -9,10 +9,14 @@ pragma solidity ^0.8.23;
 ///
 /// @author Coinbase (https://github.com/base/eip-7702-proxy)
 interface IAccountStateValidator {
+    /// @notice Error thrown when the implementation provided to `validateAccountState` is not the validator's expected implementation
+    error InvalidImplementation(address expected, address actual);
+
     /// @notice Validates that an account is in a valid state
     ///
     /// @dev Should revert if account state is invalid
     ///
     /// @param account The address of the account to validate
-    function validateAccountState(address account) external view;
+    /// @param implementation The address of the implementation this validator expects
+    function validateAccountState(address account, address implementation) external view;
 }

--- a/src/validators/CoinbaseSmartWalletValidator.sol
+++ b/src/validators/CoinbaseSmartWalletValidator.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.23;
 
 import {MultiOwnable} from "smart-wallet/MultiOwnable.sol";
 import {CoinbaseSmartWallet} from "smart-wallet/CoinbaseSmartWallet.sol";
-import {IAccountStateValidator} from "../interfaces/IAccountStateValidator.sol";
+import {IAccountStateValidator, VALIDATION_SUCCESS} from "../interfaces/IAccountStateValidator.sol";
 
 /// @title CoinbaseSmartWalletValidator
 ///
@@ -22,10 +22,11 @@ contract CoinbaseSmartWalletValidator is IAccountStateValidator {
     /// @inheritdoc IAccountStateValidator
     ///
     /// @dev Mimics the exact logic used in `CoinbaseSmartWallet.initialize` for consistency
-    function validateAccountState(address account, address implementation) external view override {
+    function validateAccountState(address account, address implementation) external view override returns (bytes4) {
         if (implementation != address(walletImplementation)) {
             revert InvalidImplementation(address(walletImplementation), implementation);
         }
         if (MultiOwnable(account).nextOwnerIndex() == 0) revert Unintialized();
+        return VALIDATION_SUCCESS;
     }
 }

--- a/src/validators/CoinbaseSmartWalletValidator.sol
+++ b/src/validators/CoinbaseSmartWalletValidator.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.23;
 
 import {MultiOwnable} from "smart-wallet/MultiOwnable.sol";
-
+import {CoinbaseSmartWallet} from "smart-wallet/CoinbaseSmartWallet.sol";
 import {IAccountStateValidator} from "../interfaces/IAccountStateValidator.sol";
 
 /// @title CoinbaseSmartWalletValidator
@@ -12,10 +12,20 @@ contract CoinbaseSmartWalletValidator is IAccountStateValidator {
     /// @notice Error thrown when an account has no nextOwnerIndex
     error Unintialized();
 
+    /// @notice The implementation of the CoinbaseSmartWallet this validator expects
+    CoinbaseSmartWallet public immutable walletImplementation;
+
+    constructor(CoinbaseSmartWallet _walletImplementation) {
+        walletImplementation = _walletImplementation;
+    }
+
     /// @inheritdoc IAccountStateValidator
     ///
     /// @dev Mimics the exact logic used in `CoinbaseSmartWallet.initialize` for consistency
-    function validateAccountState(address account) external view override {
+    function validateAccountState(address account, address implementation) external view override {
+        if (implementation != address(walletImplementation)) {
+            revert InvalidImplementation(address(walletImplementation), implementation);
+        }
         if (MultiOwnable(account).nextOwnerIndex() == 0) revert Unintialized();
     }
 }

--- a/src/validators/CoinbaseSmartWalletValidator.sol
+++ b/src/validators/CoinbaseSmartWalletValidator.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.23;
 
 import {MultiOwnable} from "smart-wallet/MultiOwnable.sol";
 import {CoinbaseSmartWallet} from "smart-wallet/CoinbaseSmartWallet.sol";
-import {IAccountStateValidator, VALIDATION_SUCCESS} from "../interfaces/IAccountStateValidator.sol";
+import {IAccountStateValidator, ACCOUNT_STATE_VALIDATION_SUCCESS} from "../interfaces/IAccountStateValidator.sol";
 
 /// @title CoinbaseSmartWalletValidator
 ///
@@ -13,20 +13,24 @@ contract CoinbaseSmartWalletValidator is IAccountStateValidator {
     error Unintialized();
 
     /// @notice The implementation of the CoinbaseSmartWallet this validator expects
-    CoinbaseSmartWallet public immutable walletImplementation;
+    CoinbaseSmartWallet internal immutable _supportedImplementation;
 
-    constructor(CoinbaseSmartWallet _walletImplementation) {
-        walletImplementation = _walletImplementation;
+    constructor(CoinbaseSmartWallet supportedImplementation) {
+        _supportedImplementation = supportedImplementation;
+    }
+
+    function supportedImplementation() external view override returns (address) {
+        return address(_supportedImplementation);
     }
 
     /// @inheritdoc IAccountStateValidator
     ///
     /// @dev Mimics the exact logic used in `CoinbaseSmartWallet.initialize` for consistency
     function validateAccountState(address account, address implementation) external view override returns (bytes4) {
-        if (implementation != address(walletImplementation)) {
-            revert InvalidImplementation(address(walletImplementation), implementation);
+        if (implementation != address(_supportedImplementation)) {
+            revert InvalidImplementation(address(_supportedImplementation), implementation);
         }
         if (MultiOwnable(account).nextOwnerIndex() == 0) revert Unintialized();
-        return VALIDATION_SUCCESS;
+        return ACCOUNT_STATE_VALIDATION_SUCCESS;
     }
 }

--- a/test/CoinbaseSmartWalletValidator.t.sol
+++ b/test/CoinbaseSmartWalletValidator.t.sol
@@ -7,6 +7,7 @@ import {EIP7702Proxy} from "../src/EIP7702Proxy.sol";
 import {NonceTracker} from "../src/NonceTracker.sol";
 import {DefaultReceiver} from "../src/DefaultReceiver.sol";
 import {CoinbaseSmartWalletValidator} from "../src/validators/CoinbaseSmartWalletValidator.sol";
+import {IAccountStateValidator} from "../src/interfaces/IAccountStateValidator.sol";
 
 contract CoinbaseSmartWalletValidatorTest is Test {
     uint256 constant _EOA_PRIVATE_KEY = 0xA11CE;
@@ -38,7 +39,7 @@ contract CoinbaseSmartWalletValidatorTest is Test {
         _implementation = new CoinbaseSmartWallet();
         _nonceTracker = new NonceTracker();
         _receiver = new DefaultReceiver();
-        _validator = new CoinbaseSmartWalletValidator();
+        _validator = new CoinbaseSmartWalletValidator(_implementation);
 
         // Deploy proxy with receiver and nonce tracker
         _proxy = new EIP7702Proxy(address(_nonceTracker), address(_receiver));
@@ -53,7 +54,8 @@ contract CoinbaseSmartWalletValidatorTest is Test {
     function test_succeeds_whenWalletHasOwner() public {
         // Initialize proxy with an owner
         bytes memory initArgs = _createInitArgs(_newOwner);
-        bytes memory signature = _signSetImplementationData(_EOA_PRIVATE_KEY, initArgs);
+        bytes memory signature =
+            _signSetImplementationData(_EOA_PRIVATE_KEY, initArgs, address(_implementation), address(_validator));
 
         // Should not revert
         EIP7702Proxy(_eoa).setImplementation(address(_implementation), initArgs, address(_validator), signature, true);
@@ -67,7 +69,8 @@ contract CoinbaseSmartWalletValidatorTest is Test {
         owners[2] = makeAddr("owner3");
 
         bytes memory initArgs = _createInitArgsMulti(owners);
-        bytes memory signature = _signSetImplementationData(_EOA_PRIVATE_KEY, initArgs);
+        bytes memory signature =
+            _signSetImplementationData(_EOA_PRIVATE_KEY, initArgs, address(_implementation), address(_validator));
 
         // Should not revert
         EIP7702Proxy(_eoa).setImplementation(address(_implementation), initArgs, address(_validator), signature, true);
@@ -77,7 +80,8 @@ contract CoinbaseSmartWalletValidatorTest is Test {
         // Try to initialize with empty owners array
         bytes[] memory emptyOwners = new bytes[](0);
         bytes memory initArgs = abi.encodePacked(CoinbaseSmartWallet.initialize.selector, abi.encode(emptyOwners));
-        bytes memory signature = _signSetImplementationData(_EOA_PRIVATE_KEY, initArgs);
+        bytes memory signature =
+            _signSetImplementationData(_EOA_PRIVATE_KEY, initArgs, address(_implementation), address(_validator));
 
         vm.expectRevert(CoinbaseSmartWalletValidator.Unintialized.selector);
         EIP7702Proxy(_eoa).setImplementation(address(_implementation), initArgs, address(_validator), signature, true);
@@ -86,7 +90,8 @@ contract CoinbaseSmartWalletValidatorTest is Test {
     function test_succeeds_whenWalletHadOwnersButLastOwnerRemoved() public {
         // First initialize the wallet with an owner
         bytes memory initArgs = _createInitArgs(_newOwner);
-        bytes memory signature = _signSetImplementationData(_EOA_PRIVATE_KEY, initArgs);
+        bytes memory signature =
+            _signSetImplementationData(_EOA_PRIVATE_KEY, initArgs, address(_implementation), address(_validator));
         EIP7702Proxy(_eoa).setImplementation(address(_implementation), initArgs, address(_validator), signature, true);
 
         // Now remove the owner through the wallet interface
@@ -97,10 +102,30 @@ contract CoinbaseSmartWalletValidatorTest is Test {
         );
 
         // Direct validation call should succeed since nextOwnerIndex is still non-zero
-        _validator.validateAccountState(address(_eoa));
+        _validator.validateAccountState(address(_eoa), address(_implementation));
 
         // Verify that nextOwnerIndex is indeed still non-zero
         assertGt(CoinbaseSmartWallet(payable(_eoa)).nextOwnerIndex(), 0);
+    }
+
+    function test_reverts_whenImplementationDoesNotMatch() public {
+        // Deploy a different implementation
+        CoinbaseSmartWallet differentImpl = new CoinbaseSmartWallet();
+
+        // Create validator with specific implementation
+        CoinbaseSmartWalletValidator validator = new CoinbaseSmartWalletValidator(differentImpl);
+
+        // Initialize proxy with an owner but using wrong implementation
+        bytes memory initArgs = _createInitArgs(_newOwner);
+        bytes memory signature =
+            _signSetImplementationData(_EOA_PRIVATE_KEY, initArgs, address(_implementation), address(validator));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccountStateValidator.InvalidImplementation.selector, address(differentImpl), address(_implementation)
+            )
+        );
+        EIP7702Proxy(_eoa).setImplementation(address(_implementation), initArgs, address(validator), signature, true);
     }
 
     // Helper functions from coinbaseImplementation.t.sol
@@ -120,7 +145,12 @@ contract CoinbaseSmartWalletValidatorTest is Test {
         return abi.encodePacked(CoinbaseSmartWallet.initialize.selector, ownerArgs);
     }
 
-    function _signSetImplementationData(uint256 signerPk, bytes memory initArgs) internal view returns (bytes memory) {
+    function _signSetImplementationData(
+        uint256 signerPk,
+        bytes memory initArgs,
+        address implementation,
+        address validator
+    ) internal view returns (bytes memory) {
         bytes32 initHash = keccak256(
             abi.encode(
                 _IMPLEMENTATION_SET_TYPEHASH,
@@ -128,9 +158,9 @@ contract CoinbaseSmartWalletValidatorTest is Test {
                 _proxy,
                 _nonceTracker.nonces(_eoa),
                 _getERC1967Implementation(address(_eoa)),
-                address(_implementation),
+                address(implementation),
                 keccak256(initArgs),
-                address(_validator)
+                address(validator)
             )
         );
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPk, initHash);

--- a/test/CoinbaseSmartWalletValidator.t.sol
+++ b/test/CoinbaseSmartWalletValidator.t.sol
@@ -108,6 +108,19 @@ contract CoinbaseSmartWalletValidatorTest is Test {
         assertGt(CoinbaseSmartWallet(payable(_eoa)).nextOwnerIndex(), 0);
     }
 
+    function test_supportedImplementation_returnsExpectedImplementation() public {
+        // Deploy a new implementation and validator
+        CoinbaseSmartWallet newImplementation = new CoinbaseSmartWallet();
+        CoinbaseSmartWalletValidator validator = new CoinbaseSmartWalletValidator(newImplementation);
+
+        // Check that supportedImplementation returns the expected address
+        assertEq(
+            validator.supportedImplementation(),
+            address(newImplementation),
+            "Supported implementation should match constructor argument"
+        );
+    }
+
     function test_reverts_whenImplementationDoesNotMatch() public {
         // Deploy a different implementation
         CoinbaseSmartWallet differentImpl = new CoinbaseSmartWallet();

--- a/test/EIP7702Proxy/coinbaseImplementation.t.sol
+++ b/test/EIP7702Proxy/coinbaseImplementation.t.sol
@@ -50,7 +50,7 @@ contract CoinbaseImplementationTest is Test {
         _cbswImplementation = new CoinbaseSmartWallet();
         _nonceTracker = new NonceTracker();
         _receiver = new DefaultReceiver();
-        _cbswValidator = new CoinbaseSmartWalletValidator();
+        _cbswValidator = new CoinbaseSmartWalletValidator(_cbswImplementation);
 
         // Deploy proxy with receiver and nonce tracker
         _proxy = new EIP7702Proxy(address(_nonceTracker), address(_receiver));

--- a/test/EIP7702Proxy/delegate.t.sol
+++ b/test/EIP7702Proxy/delegate.t.sol
@@ -5,6 +5,7 @@ import {EIP7702Proxy} from "../../src/EIP7702Proxy.sol";
 import {DefaultReceiver} from "../../src/DefaultReceiver.sol";
 import {EIP7702ProxyBase} from "../base/EIP7702ProxyBase.sol";
 import {MockImplementation} from "../mocks/MockImplementation.sol";
+import {MockValidator} from "../mocks/MockValidator.sol";
 
 contract DelegateTest is EIP7702ProxyBase {
     function setUp() public override {
@@ -48,20 +49,21 @@ contract DelegateTest is EIP7702ProxyBase {
 
         // Deploy a new implementation
         MockImplementation newImplementation = new MockImplementation();
-
+        MockValidator newImplementationValidator = new MockValidator(newImplementation);
         // Create signature for upgrade
         bytes memory signature = _signSetImplementationData(
             _EOA_PRIVATE_KEY,
             address(newImplementation),
             0, // chainId 0 for cross-chain
-            ""
+            "",
+            address(newImplementationValidator)
         );
 
         // Upgrade to the new implementation
         EIP7702Proxy(_eoa).setImplementation(
             address(newImplementation),
             "", // no init data needed
-            address(_validator),
+            address(newImplementationValidator),
             signature,
             true
         );

--- a/test/EIP7702Proxy/isValidSignature.t.sol
+++ b/test/EIP7702Proxy/isValidSignature.t.sol
@@ -73,7 +73,7 @@ contract FailingImplementationTest is IsValidSignatureTestBase {
         _implementation = new FailingSignatureImplementation();
         _nonceTracker = new NonceTracker();
         _receiver = new DefaultReceiver();
-        _validator = new MockValidator();
+        _validator = new MockValidator(_implementation);
 
         _eoa = payable(vm.addr(_EOA_PRIVATE_KEY));
         _newOwner = payable(vm.addr(_NEW_OWNER_PRIVATE_KEY));
@@ -89,7 +89,8 @@ contract FailingImplementationTest is IsValidSignatureTestBase {
             _EOA_PRIVATE_KEY,
             address(_implementation),
             0, // chainId 0 for cross-chain
-            initArgs
+            initArgs,
+            address(_validator)
         );
 
         EIP7702Proxy(_eoa).setImplementation(
@@ -175,7 +176,7 @@ contract SucceedingImplementationTest is IsValidSignatureTestBase {
         _implementation = new MockImplementation();
         _nonceTracker = new NonceTracker();
         _receiver = new DefaultReceiver();
-        _validator = new MockValidator();
+        _validator = new MockValidator(_implementation);
 
         _eoa = payable(vm.addr(_EOA_PRIVATE_KEY));
         _newOwner = payable(vm.addr(_NEW_OWNER_PRIVATE_KEY));
@@ -191,7 +192,8 @@ contract SucceedingImplementationTest is IsValidSignatureTestBase {
             _EOA_PRIVATE_KEY,
             address(_implementation),
             0, // chainId 0 for cross-chain
-            initArgs
+            initArgs,
+            address(_validator)
         );
 
         EIP7702Proxy(_eoa).setImplementation(address(_implementation), initArgs, address(_validator), signature, true);
@@ -218,7 +220,7 @@ contract RevertingImplementationTest is IsValidSignatureTestBase {
         _implementation = new RevertingIsValidSignatureImplementation();
         _nonceTracker = new NonceTracker();
         _receiver = new DefaultReceiver();
-        _validator = new MockValidator();
+        _validator = new MockValidator(_implementation);
 
         _eoa = payable(vm.addr(_EOA_PRIVATE_KEY));
         _newOwner = payable(vm.addr(_NEW_OWNER_PRIVATE_KEY));
@@ -234,7 +236,8 @@ contract RevertingImplementationTest is IsValidSignatureTestBase {
             _EOA_PRIVATE_KEY,
             address(_implementation),
             0, // chainId 0 for cross-chain
-            initArgs
+            initArgs,
+            address(_validator)
         );
 
         EIP7702Proxy(_eoa).setImplementation(address(_implementation), initArgs, address(_validator), signature, true);
@@ -274,7 +277,7 @@ contract ExtraDataTest is IsValidSignatureTestBase {
         _implementation = new MockImplementationWithExtraData();
         _nonceTracker = new NonceTracker();
         _receiver = new DefaultReceiver();
-        _validator = new MockValidator();
+        _validator = new MockValidator(_implementation);
 
         _eoa = payable(vm.addr(_EOA_PRIVATE_KEY));
         _newOwner = payable(vm.addr(_NEW_OWNER_PRIVATE_KEY));
@@ -290,7 +293,8 @@ contract ExtraDataTest is IsValidSignatureTestBase {
             _EOA_PRIVATE_KEY,
             address(_implementation),
             0, // chainId 0 for cross-chain
-            initArgs
+            initArgs,
+            address(_validator)
         );
 
         EIP7702Proxy(_eoa).setImplementation(address(_implementation), initArgs, address(_validator), signature, true);

--- a/test/EIP7702Proxy/setImplementation.t.sol
+++ b/test/EIP7702Proxy/setImplementation.t.sol
@@ -11,6 +11,8 @@ import {IERC1967} from "openzeppelin-contracts/contracts/interfaces/IERC1967.sol
 import {EIP7702ProxyBase} from "../base/EIP7702ProxyBase.sol";
 import {MockImplementation} from "../mocks/MockImplementation.sol";
 import {MockRevertingValidator} from "../mocks/MockRevertingValidator.sol";
+import {IAccountStateValidator} from "../../src/interfaces/IAccountStateValidator.sol";
+import {MockValidator} from "../mocks/MockValidator.sol";
 
 contract SetImplementationTest is EIP7702ProxyBase {
     MockImplementation _newImplementation;
@@ -28,7 +30,8 @@ contract SetImplementationTest is EIP7702ProxyBase {
             _EOA_PRIVATE_KEY,
             address(_implementation),
             0, // chainId 0 for cross-chain
-            initArgs
+            initArgs,
+            address(_validator)
         );
         EIP7702Proxy(_eoa).setImplementation(
             address(_implementation),
@@ -49,17 +52,20 @@ contract SetImplementationTest is EIP7702ProxyBase {
             address(_implementation),
             "Implementation should be set to standard implementation"
         );
+        MockValidator newImplementationValidator = new MockValidator(_newImplementation);
+
         bytes memory signature = _signSetImplementationData(
             _EOA_PRIVATE_KEY,
             address(_newImplementation),
             0, // chainId 0 for cross-chain
-            "" // empty calldata
+            "", // empty calldata
+            address(newImplementationValidator)
         );
 
         EIP7702Proxy(_eoa).setImplementation(
             address(_newImplementation),
             "",
-            address(_validator), // same validator
+            address(newImplementationValidator), // same validator
             signature,
             true // allow cross-chain replay
         );
@@ -75,7 +81,8 @@ contract SetImplementationTest is EIP7702ProxyBase {
             _EOA_PRIVATE_KEY,
             address(_implementation),
             0, // chainId 0 for cross-chain
-            initArgs
+            initArgs,
+            address(_validator)
         );
 
         vm.expectEmit(true, false, false, false, address(_eoa));
@@ -97,7 +104,8 @@ contract SetImplementationTest is EIP7702ProxyBase {
             _EOA_PRIVATE_KEY,
             address(_implementation),
             0, // chainId 0 for cross-chain
-            initArgs
+            initArgs,
+            address(_validator)
         );
         EIP7702Proxy(_eoa).setImplementation(
             address(_implementation),
@@ -118,7 +126,8 @@ contract SetImplementationTest is EIP7702ProxyBase {
             _EOA_PRIVATE_KEY,
             address(_implementation),
             block.chainid, // non-zero chainId
-            initArgs
+            initArgs,
+            address(_validator)
         );
 
         EIP7702Proxy(_eoa).setImplementation(address(_implementation), initArgs, address(_validator), signature, false);
@@ -166,7 +175,8 @@ contract SetImplementationTest is EIP7702ProxyBase {
             _EOA_PRIVATE_KEY,
             address(_implementation), // same implementation
             0, // chainId 0 for cross-chain
-            "" // empty calldata
+            "", // empty calldata
+            address(_validator)
         );
 
         EIP7702Proxy(_eoa).setImplementation(
@@ -193,9 +203,13 @@ contract SetImplementationTest is EIP7702ProxyBase {
 
         for (uint8 i = 0; i < numResets; i++) {
             MockImplementation nextImplementation = new MockImplementation();
-            bytes memory signature =
-                _signSetImplementationData(_EOA_PRIVATE_KEY, address(nextImplementation), block.chainid, "");
-            EIP7702Proxy(_eoa).setImplementation(address(nextImplementation), "", address(_validator), signature, false);
+            MockValidator nextImplementationValidator = new MockValidator(nextImplementation);
+            bytes memory signature = _signSetImplementationData(
+                _EOA_PRIVATE_KEY, address(nextImplementation), block.chainid, "", address(nextImplementationValidator)
+            );
+            EIP7702Proxy(_eoa).setImplementation(
+                address(nextImplementation), "", address(nextImplementationValidator), signature, false
+            );
 
             assertEq(_nonceTracker.nonces(_eoa), initialNonce + i + 1, "Nonce should increment by one after each reset");
         }
@@ -208,7 +222,8 @@ contract SetImplementationTest is EIP7702ProxyBase {
             _EOA_PRIVATE_KEY,
             address(_implementation),
             0, // chainId 0 for cross-chain
-            reinitArgs // attempt to reinitialize already-initialized implementation
+            reinitArgs, // attempt to reinitialize already-initialized implementation
+            address(_validator)
         );
 
         vm.expectRevert();
@@ -329,8 +344,9 @@ contract SetImplementationTest is EIP7702ProxyBase {
         );
 
         // create signature for original proxy
-        bytes memory signature =
-            _signSetImplementationData(_EOA_PRIVATE_KEY, address(_newImplementation), block.chainid, "");
+        bytes memory signature = _signSetImplementationData(
+            _EOA_PRIVATE_KEY, address(_newImplementation), block.chainid, "", address(_validator)
+        );
 
         // attempt to play signature on second proxy
         vm.expectRevert(EIP7702Proxy.InvalidSignature.selector);
@@ -349,7 +365,8 @@ contract SetImplementationTest is EIP7702ProxyBase {
             _EOA_PRIVATE_KEY,
             address(_implementation), // sign over standard implementation
             block.chainid,
-            initArgs
+            initArgs,
+            address(_validator)
         );
 
         vm.expectRevert(EIP7702Proxy.InvalidSignature.selector);
@@ -365,8 +382,9 @@ contract SetImplementationTest is EIP7702ProxyBase {
     function test_reverts_whenSignatureReplayedWithDifferentArgs(bytes memory differentInitArgs) public {
         bytes memory initArgs = _createInitArgs(_newOwner);
         vm.assume(keccak256(differentInitArgs) != keccak256(initArgs));
-        bytes memory signature =
-            _signSetImplementationData(_EOA_PRIVATE_KEY, address(_implementation), block.chainid, initArgs);
+        bytes memory signature = _signSetImplementationData(
+            _EOA_PRIVATE_KEY, address(_implementation), block.chainid, initArgs, address(_validator)
+        );
 
         vm.expectRevert(EIP7702Proxy.InvalidSignature.selector);
         EIP7702Proxy(_eoa).setImplementation(
@@ -379,8 +397,9 @@ contract SetImplementationTest is EIP7702ProxyBase {
         vm.assume(differentValidator != address(0));
 
         bytes memory initArgs = _createInitArgs(_newOwner);
-        bytes memory signature =
-            _signSetImplementationData(_EOA_PRIVATE_KEY, address(_implementation), block.chainid, initArgs);
+        bytes memory signature = _signSetImplementationData(
+            _EOA_PRIVATE_KEY, address(_implementation), block.chainid, initArgs, address(_validator)
+        );
 
         vm.expectRevert(EIP7702Proxy.InvalidSignature.selector);
         EIP7702Proxy(_eoa).setImplementation(address(_implementation), initArgs, differentValidator, signature, false);
@@ -413,8 +432,9 @@ contract SetImplementationTest is EIP7702ProxyBase {
 
     function test_reverts_whenSignatureReplayedWithSameNonce() public {
         bytes memory initArgs = _createInitArgs(_newOwner);
-        bytes memory signature =
-            _signSetImplementationData(_EOA_PRIVATE_KEY, address(_implementation), block.chainid, initArgs);
+        bytes memory signature = _signSetImplementationData(
+            _EOA_PRIVATE_KEY, address(_implementation), block.chainid, initArgs, address(_validator)
+        );
         EIP7702Proxy(_eoa).setImplementation(address(_implementation), initArgs, address(_validator), signature, false);
         assertEq(
             _getERC1967Implementation(_eoa),
@@ -450,5 +470,41 @@ contract SetImplementationTest is EIP7702ProxyBase {
 
         vm.expectRevert(EIP7702Proxy.InvalidSignature.selector);
         EIP7702Proxy(_eoa).setImplementation(address(_implementation), initArgs, address(_validator), signature, false);
+    }
+
+    function test_reverts_whenImplementationDoesNotMatchValidator() public {
+        MockImplementation expectedImpl = new MockImplementation();
+        MockImplementation actualImpl = new MockImplementation();
+
+        // Create mock validator expecting a specific implementation
+        MockValidator validator = new MockValidator(expectedImpl);
+
+        bytes memory signature =
+            _signSetImplementationData(_EOA_PRIVATE_KEY, address(actualImpl), 0, "", address(validator));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccountStateValidator.InvalidImplementation.selector, address(expectedImpl), address(actualImpl)
+            )
+        );
+        EIP7702Proxy(_eoa).setImplementation(address(actualImpl), "", address(validator), signature, true);
+    }
+
+    function test_succeeds_whenImplementationMatchesValidator() public {
+        // Create mock validator with matching implementation
+        MockValidator validator = new MockValidator(_implementation);
+
+        bytes memory initArgs = _createInitArgs(_newOwner);
+        bytes memory signature =
+            _signSetImplementationData(_EOA_PRIVATE_KEY, address(_implementation), 0, initArgs, address(validator));
+
+        // Should not revert
+        EIP7702Proxy(_eoa).setImplementation(address(_implementation), initArgs, address(validator), signature, true);
+
+        assertEq(
+            _getERC1967Implementation(_eoa),
+            address(_implementation),
+            "Implementation should be set to expected address"
+        );
     }
 }

--- a/test/base/EIP7702ProxyBase.sol
+++ b/test/base/EIP7702ProxyBase.sol
@@ -46,7 +46,7 @@ abstract contract EIP7702ProxyBase is Test {
         _implementation = new MockImplementation();
         _nonceTracker = new NonceTracker();
         _receiver = new DefaultReceiver();
-        _validator = new MockValidator();
+        _validator = new MockValidator(_implementation);
 
         // Deploy proxy with receiver and nonce tracker
         _proxy = new EIP7702Proxy(address(_nonceTracker), address(_receiver));
@@ -65,7 +65,8 @@ abstract contract EIP7702ProxyBase is Test {
             _EOA_PRIVATE_KEY,
             address(_implementation),
             0, // chainId 0 for cross-chain
-            initArgs
+            initArgs,
+            address(_validator)
         );
 
         EIP7702Proxy(_eoa).setImplementation(
@@ -89,7 +90,8 @@ abstract contract EIP7702ProxyBase is Test {
         uint256 signerPk,
         address newImplementationAddress,
         uint256 chainId,
-        bytes memory callData
+        bytes memory callData,
+        address validator
     ) internal view returns (bytes memory) {
         uint256 nonce = _nonceTracker.nonces(_eoa);
         address currentImpl = _getERC1967Implementation(_eoa);
@@ -103,7 +105,7 @@ abstract contract EIP7702ProxyBase is Test {
                 currentImpl,
                 newImplementationAddress,
                 keccak256(callData),
-                address(_validator)
+                validator
             )
         );
 

--- a/test/mocks/MockInvalidValidator.sol
+++ b/test/mocks/MockInvalidValidator.sol
@@ -6,6 +6,10 @@ import {IAccountStateValidator} from "../../src/interfaces/IAccountStateValidato
 /// @title MockInvalidValidator
 /// @dev Mock validator that returns an invalid magic value for testing
 contract MockInvalidValidator is IAccountStateValidator {
+    function supportedImplementation() external view returns (address) {
+        return address(this);
+    }
+
     function validateAccountState(address, address) external view returns (bytes4) {
         return bytes4(keccak256("invalid()"));
     }

--- a/test/mocks/MockInvalidValidator.sol
+++ b/test/mocks/MockInvalidValidator.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.23;
+
+import {IAccountStateValidator} from "../../src/interfaces/IAccountStateValidator.sol";
+
+/// @title MockInvalidValidator
+/// @dev Mock validator that returns an invalid magic value for testing
+contract MockInvalidValidator is IAccountStateValidator {
+    function validateAccountState(address, address) external view returns (bytes4) {
+        return bytes4(keccak256("invalid()"));
+    }
+}

--- a/test/mocks/MockRevertingValidator.sol
+++ b/test/mocks/MockRevertingValidator.sol
@@ -6,9 +6,9 @@ import {IAccountStateValidator} from "../../src/interfaces/IAccountStateValidato
 /// @title MockRevertingValidator
 /// @dev Mock validator that always reverts
 contract MockRevertingValidator is IAccountStateValidator {
-    error AlwaysReverts();
+    error InvalidValidation();
 
-    function validateAccountState(address, address) external pure {
-        revert AlwaysReverts();
+    function validateAccountState(address, address) external pure returns (bytes4) {
+        revert InvalidValidation();
     }
 }

--- a/test/mocks/MockRevertingValidator.sol
+++ b/test/mocks/MockRevertingValidator.sol
@@ -8,6 +8,10 @@ import {IAccountStateValidator} from "../../src/interfaces/IAccountStateValidato
 contract MockRevertingValidator is IAccountStateValidator {
     error InvalidValidation();
 
+    function supportedImplementation() external view returns (address) {
+        return address(0);
+    }
+
     function validateAccountState(address, address) external pure returns (bytes4) {
         revert InvalidValidation();
     }

--- a/test/mocks/MockRevertingValidator.sol
+++ b/test/mocks/MockRevertingValidator.sol
@@ -2,14 +2,13 @@
 pragma solidity ^0.8.23;
 
 import {IAccountStateValidator} from "../../src/interfaces/IAccountStateValidator.sol";
-import {MockImplementation} from "./MockImplementation.sol";
 
 /// @title MockRevertingValidator
 /// @dev Mock validator that always reverts
 contract MockRevertingValidator is IAccountStateValidator {
     error AlwaysReverts();
 
-    function validateAccountState(address) external pure {
+    function validateAccountState(address, address) external pure {
         revert AlwaysReverts();
     }
 }

--- a/test/mocks/MockValidator.sol
+++ b/test/mocks/MockValidator.sol
@@ -11,11 +11,24 @@ import {MockImplementation} from "./MockImplementation.sol";
 contract MockValidator is IAccountStateValidator {
     error WalletNotInitialized();
 
+    MockImplementation public immutable expectedImplementation;
+
+    constructor(MockImplementation _expectedImplementation) {
+        expectedImplementation = _expectedImplementation;
+    }
+
     /**
      * @dev Validates that the wallet is initialized
      * @param wallet Address of the wallet to validate
+     * @param implementation Address of the expected implementation
      */
-    function validateAccountState(address wallet) external view {
+    function validateAccountState(address wallet, address implementation) external view {
+        // Check implementation first
+        if (implementation != address(expectedImplementation)) {
+            revert InvalidImplementation(address(expectedImplementation), implementation);
+        }
+
+        // Then check initialization
         bool isInitialized = MockImplementation(wallet).initialized();
         if (!isInitialized) revert WalletNotInitialized();
     }

--- a/test/mocks/MockValidator.sol
+++ b/test/mocks/MockValidator.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.23;
 
-import {IAccountStateValidator, VALIDATION_SUCCESS} from "../../src/interfaces/IAccountStateValidator.sol";
+import {
+    IAccountStateValidator, ACCOUNT_STATE_VALIDATION_SUCCESS
+} from "../../src/interfaces/IAccountStateValidator.sol";
 import {MockImplementation} from "./MockImplementation.sol";
 
 /**
@@ -17,6 +19,10 @@ contract MockValidator is IAccountStateValidator {
         expectedImplementation = _expectedImplementation;
     }
 
+    function supportedImplementation() external view returns (address) {
+        return address(expectedImplementation);
+    }
+
     /**
      * @dev Validates that the wallet is initialized
      * @param wallet Address of the wallet to validate
@@ -29,6 +35,6 @@ contract MockValidator is IAccountStateValidator {
 
         bool isInitialized = MockImplementation(wallet).initialized();
         if (!isInitialized) revert WalletNotInitialized();
-        return VALIDATION_SUCCESS;
+        return ACCOUNT_STATE_VALIDATION_SUCCESS;
     }
 }

--- a/test/mocks/MockValidator.sol
+++ b/test/mocks/MockValidator.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.23;
 
-import {IAccountStateValidator} from "../../src/interfaces/IAccountStateValidator.sol";
+import {IAccountStateValidator, VALIDATION_SUCCESS} from "../../src/interfaces/IAccountStateValidator.sol";
 import {MockImplementation} from "./MockImplementation.sol";
 
 /**
@@ -22,14 +22,13 @@ contract MockValidator is IAccountStateValidator {
      * @param wallet Address of the wallet to validate
      * @param implementation Address of the expected implementation
      */
-    function validateAccountState(address wallet, address implementation) external view {
-        // Check implementation first
+    function validateAccountState(address wallet, address implementation) external view returns (bytes4) {
         if (implementation != address(expectedImplementation)) {
             revert InvalidImplementation(address(expectedImplementation), implementation);
         }
 
-        // Then check initialization
         bool isInitialized = MockImplementation(wallet).initialized();
         if (!isInitialized) revert WalletNotInitialized();
+        return VALIDATION_SUCCESS;
     }
 }


### PR DESCRIPTION
A fix for audit finding #1 in audit from 03/05/25: `validateAccountState()` may be called on an incorrect validator.

Requires validators to be established with an expected implementation they are responsible for validating. The `setImplementation` function then passes the new implementation being established to ensure that not only does the validator pass, but it's the correct validator for the implementation.

Additionally, has validators return a magic value instead of relying on revert behavior since incorrectly implemented validators or EOAs may simply not revert when called.