### PR TITLE
Validate actual ERC-1967 slot

### DIFF
--- a/src/EIP7702Proxy.sol
+++ b/src/EIP7702Proxy.sol
@@ -98,7 +98,7 @@ contract EIP7702Proxy is Proxy {
 
         // Validate wallet state after upgrade, reverting if invalid
         bytes4 validationResult =
-            IAccountStateValidator(validator).validateAccountState(address(this), newImplementation);
+            IAccountStateValidator(validator).validateAccountState(address(this), ERC1967Utils.getImplementation());
         if (validationResult != ACCOUNT_STATE_VALIDATION_SUCCESS) revert InvalidValidation();
     }
 

--- a/src/interfaces/IAccountStateValidator.sol
+++ b/src/interfaces/IAccountStateValidator.sol
@@ -12,9 +12,6 @@ interface IAccountStateValidator {
     /// @notice Error thrown when the implementation provided to `validateAccountState` is not a supported implementation
     error InvalidImplementation(address actual);
 
-    /// @notice Returns an array of implementations this validator is capable of validating
-    function supportedImplementations() external view returns (address[] memory);
-
     /// @notice Validates that an account is in a valid state
     /// @dev Should return ACCOUNT_STATE_VALIDATION_SUCCESS if account state is valid, otherwise revert
     /// @dev Should validate that the provided implementation is a supported implementation for this validator

--- a/src/interfaces/IAccountStateValidator.sol
+++ b/src/interfaces/IAccountStateValidator.sol
@@ -9,17 +9,17 @@ bytes4 constant ACCOUNT_STATE_VALIDATION_SUCCESS = 0x61014884; // bytes4(keccak2
 /// @dev This interface is used to validate the state of a account after an upgrade
 /// @author Coinbase (https://github.com/base/eip-7702-proxy)
 interface IAccountStateValidator {
-    /// @notice Error thrown when the implementation provided to `validateAccountState` is not the validator's expected implementation
-    error InvalidImplementation(address expected, address actual);
+    /// @notice Error thrown when the implementation provided to `validateAccountState` is not a supported implementation
+    error InvalidImplementation(address actual);
 
-    /// @notice Returns the address of the implementation this validator is willing to validate
-    function supportedImplementation() external view returns (address);
+    /// @notice Returns an array of implementations this validator is capable of validating
+    function supportedImplementations() external view returns (address[] memory);
 
     /// @notice Validates that an account is in a valid state
     /// @dev Should return ACCOUNT_STATE_VALIDATION_SUCCESS if account state is valid, otherwise revert
-    /// @dev Should validate that the provided implementation is the expected implementation for this validator
+    /// @dev Should validate that the provided implementation is a supported implementation for this validator
     /// @param account The address of the account to validate
-    /// @param implementation The address of the implementation this validator expects
+    /// @param implementation The address of the implementation being validated
     /// @return The magic value ACCOUNT_STATE_VALIDATION_SUCCESS if validation succeeds
     function validateAccountState(address account, address implementation) external view returns (bytes4);
 }

--- a/src/validators/CoinbaseSmartWalletValidator.sol
+++ b/src/validators/CoinbaseSmartWalletValidator.sol
@@ -19,12 +19,6 @@ contract CoinbaseSmartWalletValidator is IAccountStateValidator {
         _supportedImplementation = supportedImplementation;
     }
 
-    function supportedImplementations() external view override returns (address[] memory) {
-        address[] memory implementations = new address[](1);
-        implementations[0] = address(_supportedImplementation);
-        return implementations;
-    }
-
     /// @inheritdoc IAccountStateValidator
     ///
     /// @dev Mimics the exact logic used in `CoinbaseSmartWallet.initialize` for consistency

--- a/src/validators/CoinbaseSmartWalletValidator.sol
+++ b/src/validators/CoinbaseSmartWalletValidator.sol
@@ -9,7 +9,7 @@ import {IAccountStateValidator, ACCOUNT_STATE_VALIDATION_SUCCESS} from "../inter
 ///
 /// @notice Validates account state against invariants specific to CoinbaseSmartWallet
 contract CoinbaseSmartWalletValidator is IAccountStateValidator {
-    /// @notice Error thrown when an account has no nextOwnerIndex
+    /// @notice Error thrown when an account's nextOwnerIndex is 0
     error Unintialized();
 
     /// @notice The implementation of the CoinbaseSmartWallet this validator expects
@@ -19,8 +19,10 @@ contract CoinbaseSmartWalletValidator is IAccountStateValidator {
         _supportedImplementation = supportedImplementation;
     }
 
-    function supportedImplementation() external view override returns (address) {
-        return address(_supportedImplementation);
+    function supportedImplementations() external view override returns (address[] memory) {
+        address[] memory implementations = new address[](1);
+        implementations[0] = address(_supportedImplementation);
+        return implementations;
     }
 
     /// @inheritdoc IAccountStateValidator
@@ -28,7 +30,7 @@ contract CoinbaseSmartWalletValidator is IAccountStateValidator {
     /// @dev Mimics the exact logic used in `CoinbaseSmartWallet.initialize` for consistency
     function validateAccountState(address account, address implementation) external view override returns (bytes4) {
         if (implementation != address(_supportedImplementation)) {
-            revert InvalidImplementation(address(_supportedImplementation), implementation);
+            revert InvalidImplementation(implementation);
         }
         if (MultiOwnable(account).nextOwnerIndex() == 0) revert Unintialized();
         return ACCOUNT_STATE_VALIDATION_SUCCESS;

--- a/test/CoinbaseSmartWalletValidator.t.sol
+++ b/test/CoinbaseSmartWalletValidator.t.sol
@@ -108,21 +108,6 @@ contract CoinbaseSmartWalletValidatorTest is Test {
         assertGt(CoinbaseSmartWallet(payable(_eoa)).nextOwnerIndex(), 0);
     }
 
-    function test_supportedImplementations_returnsExpectedImplementation() public {
-        // Deploy a new implementation and validator
-        CoinbaseSmartWallet newImplementation = new CoinbaseSmartWallet();
-        CoinbaseSmartWalletValidator validator = new CoinbaseSmartWalletValidator(newImplementation);
-
-        address[] memory actualImplementations = new address[](1);
-        actualImplementations[0] = address(newImplementation);
-        // Check that supportedImplementations returns the expected address
-        assertEq(
-            validator.supportedImplementations(),
-            actualImplementations,
-            "Supported implementation should match constructor argument"
-        );
-    }
-
     function test_reverts_whenImplementationDoesNotMatch() public {
         // Deploy a different implementation
         CoinbaseSmartWallet differentImpl = new CoinbaseSmartWallet();

--- a/test/CoinbaseSmartWalletValidator.t.sol
+++ b/test/CoinbaseSmartWalletValidator.t.sol
@@ -108,15 +108,17 @@ contract CoinbaseSmartWalletValidatorTest is Test {
         assertGt(CoinbaseSmartWallet(payable(_eoa)).nextOwnerIndex(), 0);
     }
 
-    function test_supportedImplementation_returnsExpectedImplementation() public {
+    function test_supportedImplementations_returnsExpectedImplementation() public {
         // Deploy a new implementation and validator
         CoinbaseSmartWallet newImplementation = new CoinbaseSmartWallet();
         CoinbaseSmartWalletValidator validator = new CoinbaseSmartWalletValidator(newImplementation);
 
-        // Check that supportedImplementation returns the expected address
+        address[] memory actualImplementations = new address[](1);
+        actualImplementations[0] = address(newImplementation);
+        // Check that supportedImplementations returns the expected address
         assertEq(
-            validator.supportedImplementation(),
-            address(newImplementation),
+            validator.supportedImplementations(),
+            actualImplementations,
             "Supported implementation should match constructor argument"
         );
     }
@@ -134,9 +136,7 @@ contract CoinbaseSmartWalletValidatorTest is Test {
             _signSetImplementationData(_EOA_PRIVATE_KEY, initArgs, address(_implementation), address(validator));
 
         vm.expectRevert(
-            abi.encodeWithSelector(
-                IAccountStateValidator.InvalidImplementation.selector, address(differentImpl), address(_implementation)
-            )
+            abi.encodeWithSelector(IAccountStateValidator.InvalidImplementation.selector, address(_implementation))
         );
         EIP7702Proxy(_eoa).setImplementation(address(_implementation), initArgs, address(validator), signature, true);
     }

--- a/test/EIP7702Proxy/setImplementation.t.sol
+++ b/test/EIP7702Proxy/setImplementation.t.sol
@@ -485,9 +485,7 @@ contract SetImplementationTest is EIP7702ProxyBase {
             _signSetImplementationData(_EOA_PRIVATE_KEY, address(actualImpl), 0, "", address(validator));
 
         vm.expectRevert(
-            abi.encodeWithSelector(
-                IAccountStateValidator.InvalidImplementation.selector, address(expectedImpl), address(actualImpl)
-            )
+            abi.encodeWithSelector(IAccountStateValidator.InvalidImplementation.selector, address(actualImpl))
         );
         EIP7702Proxy(_eoa).setImplementation(address(actualImpl), "", address(validator), signature, true);
     }
@@ -566,9 +564,7 @@ contract SetImplementationTest is EIP7702ProxyBase {
         // Should revert because after initialization, the implementation
         // will be finalImpl but validator expects maliciousImpl
         vm.expectRevert(
-            abi.encodeWithSelector(
-                IAccountStateValidator.InvalidImplementation.selector, address(maliciousImpl), address(finalImpl)
-            )
+            abi.encodeWithSelector(IAccountStateValidator.InvalidImplementation.selector, address(finalImpl))
         );
         EIP7702Proxy(_eoa).setImplementation(address(maliciousImpl), initArgs, address(validator), signature, true);
     }

--- a/test/EIP7702Proxy/setImplementation.t.sol
+++ b/test/EIP7702Proxy/setImplementation.t.sol
@@ -5,7 +5,7 @@ import {EIP7702Proxy} from "../../src/EIP7702Proxy.sol";
 import {NonceTracker} from "../../src/NonceTracker.sol";
 
 import {ECDSA} from "openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
-import {ERC1967Utils} from "openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Utils.sol";
+// import {ERC1967Utils} from "openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Utils.sol";
 import {IERC1967} from "openzeppelin-contracts/contracts/interfaces/IERC1967.sol";
 
 import {EIP7702ProxyBase} from "../base/EIP7702ProxyBase.sol";
@@ -14,6 +14,7 @@ import {MockRevertingValidator} from "../mocks/MockRevertingValidator.sol";
 import {IAccountStateValidator} from "../../src/interfaces/IAccountStateValidator.sol";
 import {MockValidator} from "../mocks/MockValidator.sol";
 import {MockInvalidValidator} from "../mocks/MockInvalidValidator.sol";
+import {MockMaliciousImplementation} from "../mocks/MockMaliciousImplementation.sol";
 
 contract SetImplementationTest is EIP7702ProxyBase {
     MockImplementation _newImplementation;
@@ -547,5 +548,28 @@ contract SetImplementationTest is EIP7702ProxyBase {
         EIP7702Proxy(_eoa).setImplementation(
             address(_implementation), initArgs, address(nonCompliantValidator), signature, true
         );
+    }
+
+    function test_reverts_whenImplementationChangesItsOwnImplementation() public {
+        // Create a chain of implementations
+        MockImplementation finalImpl = new MockImplementation();
+        MockMaliciousImplementation maliciousImpl = new MockMaliciousImplementation(address(finalImpl));
+
+        // Create validator expecting the malicious implementation
+        MockValidator validator = new MockValidator(maliciousImpl);
+
+        // Try to initialize with the malicious implementation
+        bytes memory initArgs = _createInitArgs(_newOwner);
+        bytes memory signature =
+            _signSetImplementationData(_EOA_PRIVATE_KEY, address(maliciousImpl), 0, initArgs, address(validator));
+
+        // Should revert because after initialization, the implementation
+        // will be finalImpl but validator expects maliciousImpl
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccountStateValidator.InvalidImplementation.selector, address(maliciousImpl), address(finalImpl)
+            )
+        );
+        EIP7702Proxy(_eoa).setImplementation(address(maliciousImpl), initArgs, address(validator), signature, true);
     }
 }

--- a/test/mocks/MockInvalidValidator.sol
+++ b/test/mocks/MockInvalidValidator.sol
@@ -6,8 +6,10 @@ import {IAccountStateValidator} from "../../src/interfaces/IAccountStateValidato
 /// @title MockInvalidValidator
 /// @dev Mock validator that returns an invalid magic value for testing
 contract MockInvalidValidator is IAccountStateValidator {
-    function supportedImplementation() external view returns (address) {
-        return address(this);
+    function supportedImplementations() external view returns (address[] memory) {
+        address[] memory implementations = new address[](1);
+        implementations[0] = address(this);
+        return implementations;
     }
 
     function validateAccountState(address, address) external view returns (bytes4) {

--- a/test/mocks/MockInvalidValidator.sol
+++ b/test/mocks/MockInvalidValidator.sol
@@ -6,12 +6,6 @@ import {IAccountStateValidator} from "../../src/interfaces/IAccountStateValidato
 /// @title MockInvalidValidator
 /// @dev Mock validator that returns an invalid magic value for testing
 contract MockInvalidValidator is IAccountStateValidator {
-    function supportedImplementations() external view returns (address[] memory) {
-        address[] memory implementations = new address[](1);
-        implementations[0] = address(this);
-        return implementations;
-    }
-
     function validateAccountState(address, address) external view returns (bytes4) {
         return bytes4(keccak256("invalid()"));
     }

--- a/test/mocks/MockMaliciousImplementation.sol
+++ b/test/mocks/MockMaliciousImplementation.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.23;
+
+import {ERC1967Utils} from "openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Utils.sol";
+import {MockImplementation} from "./MockImplementation.sol";
+
+/// @dev Mock implementation that tries to change its own implementation during initialization
+contract MockMaliciousImplementation is MockImplementation {
+    address public immutable targetImplementation;
+
+    constructor(address _targetImplementation) {
+        targetImplementation = _targetImplementation;
+    }
+
+    function initialize(address _owner) public override {
+        // First do normal initialization
+        super.initialize(_owner);
+
+        // Then try to change implementation to something else
+        ERC1967Utils.upgradeToAndCall(targetImplementation, "");
+    }
+}

--- a/test/mocks/MockRevertingValidator.sol
+++ b/test/mocks/MockRevertingValidator.sol
@@ -8,10 +8,6 @@ import {IAccountStateValidator} from "../../src/interfaces/IAccountStateValidato
 contract MockRevertingValidator is IAccountStateValidator {
     error InvalidValidation();
 
-    function supportedImplementations() external view returns (address[] memory) {
-        return new address[](0);
-    }
-
     function validateAccountState(address, address) external pure returns (bytes4) {
         revert InvalidValidation();
     }

--- a/test/mocks/MockRevertingValidator.sol
+++ b/test/mocks/MockRevertingValidator.sol
@@ -8,8 +8,8 @@ import {IAccountStateValidator} from "../../src/interfaces/IAccountStateValidato
 contract MockRevertingValidator is IAccountStateValidator {
     error InvalidValidation();
 
-    function supportedImplementation() external view returns (address) {
-        return address(0);
+    function supportedImplementations() external view returns (address[] memory) {
+        return new address[](0);
     }
 
     function validateAccountState(address, address) external pure returns (bytes4) {

--- a/test/mocks/MockValidator.sol
+++ b/test/mocks/MockValidator.sol
@@ -19,12 +19,6 @@ contract MockValidator is IAccountStateValidator {
         expectedImplementation = _expectedImplementation;
     }
 
-    function supportedImplementations() external view returns (address[] memory) {
-        address[] memory implementations = new address[](1);
-        implementations[0] = address(expectedImplementation);
-        return implementations;
-    }
-
     /**
      * @dev Validates that the wallet is initialized
      * @param wallet Address of the wallet to validate

--- a/test/mocks/MockValidator.sol
+++ b/test/mocks/MockValidator.sol
@@ -19,8 +19,10 @@ contract MockValidator is IAccountStateValidator {
         expectedImplementation = _expectedImplementation;
     }
 
-    function supportedImplementation() external view returns (address) {
-        return address(expectedImplementation);
+    function supportedImplementations() external view returns (address[] memory) {
+        address[] memory implementations = new address[](1);
+        implementations[0] = address(expectedImplementation);
+        return implementations;
     }
 
     /**
@@ -30,7 +32,7 @@ contract MockValidator is IAccountStateValidator {
      */
     function validateAccountState(address wallet, address implementation) external view returns (bytes4) {
         if (implementation != address(expectedImplementation)) {
-            revert InvalidImplementation(address(expectedImplementation), implementation);
+            revert InvalidImplementation(implementation);
         }
 
         bool isInitialized = MockImplementation(wallet).initialized();


### PR DESCRIPTION
Updates the validation logic to pass the actual retrieved ERC1967 implementation slot to the validator, which may not be the `newImplementation` if the `upgradeToAndCall` function on the `newImplementation` itself calls `upgradeToOrCall` or otherwise has unexpected effects on the final value of the implementation.

Also removes the concept of a `supportedImplementation` from the `IAccountStateValidator` interface since it's not needed by this system for which the validator is designed.