### PR TITLE
chore: Fix typo in interface description

### DIFF
--- a/src/interfaces/IAccountStateValidator.sol
+++ b/src/interfaces/IAccountStateValidator.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.23;
 bytes4 constant ACCOUNT_STATE_VALIDATION_SUCCESS = 0xccd10cc8; // bytes4(keccak256("validateAccountState(address,address)"))
 
 /// @title IAccountStateValidator
-/// @notice Interface for account-specific validation logi
+/// @notice Interface for account-specific validation logic
 /// @dev This interface is used to validate the state of a account after an upgrade
 /// @author Coinbase (https://github.com/base/eip-7702-proxy)
 interface IAccountStateValidator {


### PR DESCRIPTION
i’ve corrected a small typo in the interface description.
the word "logi" has been updated to "**logic**".