### PR TITLE
docs: Fix typo in reference to Solady library

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The EIP-7702 Proxy provides a secure way to upgrade EOAs to smart contract walle
 - Reverts invalid state transitions
 
 ### DefaultReceiver
-- Inherits from Solady's `Receiver`
+- Inherits from Solady `Receiver`
 - Provides a default implementation for token compatibility
 
 ## Usage


### PR DESCRIPTION
i’ve corrected the reference to the Solady library.
the possessive form "Solady's" was replaced with "Solady" as it's just a library name and not something that requires an apostrophe.